### PR TITLE
Update push issue report for missing remote configuration

### DIFF
--- a/PUSH_ISSUE_REPORT.md
+++ b/PUSH_ISSUE_REPORT.md
@@ -5,14 +5,17 @@
 - `git push` を実行すると、プッシュ先が設定されていない旨のエラーが表示されました。
 
 ## 原因
-リポジトリにリモートが設定されていないため、`git push` の送信先が存在せず、プッシュが失敗します。
+リポジトリにリモートが設定されていないため、`git push` の送信先が存在せず、プッシュが失敗します。また、想定されていたリモートリポジトリ
+`/workspace/ez-manual-simplifier-remote.git` も現在は存在しません。
 
 ## 対応状況
-- `/workspace/ez-manual-simplifier-remote.git` にベアリポジトリを作成し、プッシュ先として利用できるようにしました。
-- `git remote add origin ../ez-manual-simplifier-remote.git` を実行し、ローカルリポジトリに `origin` を設定しました。
+- リモート設定およびベアリポジトリは再度未整備の状態です。
+- `git remote -v` を実行しても出力がなく、`origin` が未登録であることを確認しました。
 
 ## 今後の運用
-1. 初回プッシュ時は `git push -u origin <ブランチ名>` を実行してください。
-2. 2回目以降は `git push` のみでプッシュできます。
+1. `/workspace` 直下にベアリポジトリ（例: `git init --bare /workspace/ez-manual-simplifier-remote.git`）を作成します。
+2. `git remote add origin ../ez-manual-simplifier-remote.git` を実行し、ローカルリポジトリにリモートを登録します。
+3. 初回プッシュ時は `git push -u origin <ブランチ名>` を実行してください。
+4. 2回目以降は `git push` のみでプッシュできます。
 
-リモートが正しく設定されたため、以後は通常通りプッシュ可能です。
+上記の対応を行うまではプッシュに失敗し続けます。必要に応じてリモートの存在と設定状況を再確認してください。


### PR DESCRIPTION
## Summary
- document that the local repository no longer has a configured remote
- note that the previously expected bare repository `/workspace/ez-manual-simplifier-remote.git` is missing
- outline the steps required to recreate the bare repository and restore the remote configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57e7b527c8329912371d490aafb1f