### PR TITLE
🔧 Disable MD031 and MD032 markdownlint rules to improve workflow

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,7 @@
   "MD013": false,
   "MD004": { "style": "consistent" },
   "MD024": { "allow_different_nesting": true },
-  "MD001": false
+  "MD001": false,
+  "MD031": false,
+  "MD032": false
 }


### PR DESCRIPTION
# プルリクエスト

## 📋 概要

## 変更の目的
markdownlintのリスト前後の空行ルール（MD031/MD032）を無効化し、開発効率を向上させます。

## 問題点
- リスト項目の前後に空行が必要というルールによりエラーが頻発
- ファイル作成や編集のたびに余計な対応が必要
- この作業だけで1日もの時間を消費する状況

## 変更内容
`.markdownlint.json`を更新し、以下のルールを無効化:
- `MD031`: リスト項目の前に空行を要求
- `MD032`: リスト項目の後に空行を要求

## 期待される効果
- Markdownファイル作成・編集の作業効率が向上
- CI/CDのチェックがスムーズに通過
- 実用面で問題ない範囲でフォーマットルールを緩和

## 🔧 変更点

- [ ] 主要な変更1

- [ ] 主要な変更2

- [ ] 主要な変更3

## 🧪 テスト

- [ ] 動作確認方針または結果を記載

## 🔗 関連

Closes #
Related to #


## ✅ チェックリスト

- [ ] 変更点の自己レビュー

- [ ] ドキュメント更新（必要に応じて）

- [ ] markdownlint を通過
